### PR TITLE
Correctly detect smelting recipes

### DIFF
--- a/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
+++ b/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
@@ -275,6 +275,7 @@ function GUI:EventHandler(event, ...)
 					--GUI:UpdateQueue()
 				end
 			end		
+			-- no longer casting a spell so discard spellID
 			TSM.currentspell = nil
 			-- TSMAPI:CreateTimeDelay("craftingQueueUpdateThrottle", 0.2, GUI.UpdateQueue)
 		elseif event == "UNIT_SPELLCAST_INTERRUPTED" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_FAILED_QUIET" then
@@ -289,7 +290,9 @@ function GUI:EventHandler(event, ...)
 				GUI.isCrafting.quantity = 0
 				TSMAPI:CreateTimeDelay("craftingQueueUpdateThrottle", 0.2, GUI.UpdateQueue)
 			end
-		end
+			-- no longer casting a spell so discard spellID
+			TSM.currentspell = nil
+	end
 	end
 end
 

--- a/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
+++ b/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
@@ -317,6 +317,7 @@ function GUI:UpdateTradeSkills()
 		skillName = GetSkillLineInfo(i)
 		if  skillName == "Professions" then --TRADE_SKILLS ) then
 			tradeSkill1, header = GetSkillLineInfo(i + 1);
+			if tradeSkill1 == "Mining" then tradeSkill1 = "Smelting" end
 			if header or not GetSpellInfo(tradeSkill1) then
 				tradeSkill1 = nil
 			else
@@ -324,6 +325,7 @@ function GUI:UpdateTradeSkills()
 			end
 
 			tradeSkill2, header = GetSkillLineInfo(i + 2);
+			if tradeSkill2 == "Mining" then tradeSkill2 = "Smelting" end
 			if header or not GetSpellInfo(tradeSkill2) then
 				tradeSkill2 = nil
 			else


### PR DESCRIPTION
GetSpellInfo("Mining") was returning nil, multiple spells with that Name, assume wrong one was being retrieved.  Changing tradeskill name to Smelting correctly detects recipes.

This may not be the best way to solve the issue.