### PR TITLE
Bugfix: BulkQuery->QueryTicker spammed errors if items list was empty

### DIFF
--- a/TradeSkillMaster/TradeSkillMaster.lua
+++ b/TradeSkillMaster/TradeSkillMaster.lua
@@ -134,7 +134,7 @@ local savedDBDefaults = {
 -- Called once the player has loaded WOW.
 function TSM:OnInitialize()
 	TSMAPI:RegisterForTracing(TSMAPI, "TSMAPI")
-	
+
 	TSM.moduleObjects = nil
 	TSM.moduleNames = nil
 
@@ -149,7 +149,7 @@ function TSM:OnInitialize()
 	else
 		TSM.operations = TSM.db.profile.operations
 	end
-	
+
 	-- Prepare the TradeSkillMasterAppDB database
 	-- We're not using AceDB here on purpose due to bugs in AceDB, but are emulating the parts of it that we need.
 
@@ -250,7 +250,7 @@ function TSM:OnInitialize()
 		end
 	end
 	TSMAPI:BulkQuery(bulkquerybuffer)
-	
+
 	if TSM.db.profile.deValueSource then
 		TSM.db.profile.destroyValueSource = TSM.db.profile.deValueSource
 		TSM.db.profile.deValueSource = nil
@@ -267,7 +267,7 @@ function TSM:RegisterModule()
 	}
 
 	TSM.priceSources = {}
-	
+
 	-- Auctioneer
 	if select(4, GetAddOnInfo("Auc-Advanced")) == 1 and AucAdvanced then
 		if AucAdvanced.Modules.Util.Appraiser and AucAdvanced.Modules.Util.Appraiser.GetPrice then
@@ -280,7 +280,7 @@ function TSM:RegisterModule()
 			tinsert(TSM.priceSources, { key = "AucMarket", label = L["Auctioneer - Market Value"], callback = AucAdvanced.API.GetMarketValue })
 		end
 	end
-	
+
 	-- Auctionator
 	if select(4, GetAddOnInfo("Auctionator")) == 1 and Atr_GetAuctionBuyout then
 		tinsert(TSM.priceSources, { key = "AtrValue", label = L["Auctionator - Auction Value"], callback = Atr_GetAuctionBuyout })
@@ -430,7 +430,7 @@ function TSM:GetTooltip(itemString, quantity)
 					tinsert(text, { left = "  " .. L["Disenchant Value:"], right = TSMAPI:FormatTextMoney(deValue, "|cffffffff", true) })
 				end
 			end
-			
+
 			if TSM.db.profile.detailedDestroyTooltip then
 				local _, itemLink, quality, ilvl, _, iType = TSMAPI:GetSafeItemInfo(itemString)
 				local itemString = TSMAPI:GetItemString(itemLink)
@@ -463,7 +463,7 @@ function TSM:GetTooltip(itemString, quantity)
 			end
 		end
 	end
-	
+
 	-- add mill value info
 	if TSM.db.profile.millTooltip then
 		local millValue = TSM:GetMillValue(itemString)
@@ -481,7 +481,7 @@ function TSM:GetTooltip(itemString, quantity)
 					tinsert(text, { left = "  " .. L["Mill Value:"], right = TSMAPI:FormatTextMoney(millValue, "|cffffffff", true) })
 				end
 			end
-			
+
 			if TSM.db.profile.detailedDestroyTooltip then
 				for _, targetItem in ipairs(TSMAPI:GetConversionTargetItems("mill")) do
 					local herbs = TSMAPI:GetItemConversions(targetItem)
@@ -504,7 +504,7 @@ function TSM:GetTooltip(itemString, quantity)
 			end
 		end
 	end
-	
+
 	-- add prospect value info
 	if TSM.db.profile.prospectTooltip then
 		local prospectValue = TSM:GetProspectValue(itemString)
@@ -522,7 +522,7 @@ function TSM:GetTooltip(itemString, quantity)
 					tinsert(text, { left = "  " .. L["Prospect Value:"], right = TSMAPI:FormatTextMoney(prospectValue, "|cffffffff", true) })
 				end
 			end
-			
+
 			if TSM.db.profile.detailedDestroyTooltip then
 				for _, targetItem in ipairs(TSMAPI:GetConversionTargetItems("prospect")) do
 					local gems = TSMAPI:GetItemConversions(targetItem)
@@ -589,7 +589,7 @@ function TSM:GetTooltip(itemString, quantity)
 			end
 		end
 	end
-	
+
 	for name, method in pairs(TSM.db.global.customPriceSources) do
 		if TSM.db.global.customPriceTooltips[name] then
 			local price = TSM:GetCustomPrice(name, itemString)
@@ -632,7 +632,7 @@ end
 
 function TSM:GetMillValue(itemString)
 	local value = 0
-	
+
 	for _, targetItem in ipairs(TSMAPI:GetConversionTargetItems("mill")) do
 		local herbs = TSMAPI:GetItemConversions(targetItem)
 		if herbs[itemString] then
@@ -640,13 +640,13 @@ function TSM:GetMillValue(itemString)
 			value = value + (matValue or 0) * herbs[itemString].rate
 		end
 	end
-	
+
 	return value
 end
 
 function TSM:GetProspectValue(itemString)
 	local value = 0
-	
+
 	for _, targetItem in ipairs(TSMAPI:GetConversionTargetItems("prospect")) do
 		local gems = TSMAPI:GetItemConversions(targetItem)
 		if gems[itemString] then
@@ -654,7 +654,7 @@ function TSM:GetProspectValue(itemString)
 			value = value + (matValue or 0) * gems[itemString].rate
 		end
 	end
-	
+
 	return value
 end
 
@@ -716,6 +716,7 @@ end
 
 -- Bulk load uncached IDs.  Divides in to buckets of 50
 function TSMAPI:BulkQuery(items)
+	if not items or #items == 0 then return end
 	self.QueryTicker = Timer.NewTicker(1, function()
 		Item:BulkContinueOnLoad(table.take(items, 50), function(id) end, function(id) return GetItemInfo(id) == nil end) -- 3rd parameter (validator) is optional
 		if #items == 0 then


### PR DESCRIPTION
Basically if you created a new profile with a new empty group, you would get spammed with `attempt to index field "QueryTicker"(a nil value)` 

this fixes that bug