### PR TITLE
Removed UNIT_SPELLCAST_FAILED_QUIET handling

### DIFF
--- a/TradeSkillMaster/Core/Groups.lua
+++ b/TradeSkillMaster/Core/Groups.lua
@@ -92,14 +92,14 @@ end
 -- Deletes a group with the specified path and everything (items/subGroups) below it
 local function DeleteGroup(groupPath)
 	if not TSM.db.profile.groups[groupPath] then return end
-	
+
 	-- delete this group and all subgroups
 	for path in pairs(TSM.db.profile.groups) do
 		if path == groupPath or strfind(path, "^"..TSMAPI:StrEscape(groupPath)..TSM.GROUP_SEP) then
 			TSM.db.profile.groups[path] = nil
 		end
 	end
-	
+
 	local parent = SplitGroupPath(groupPath)
 	if parent and TSM.db.profile.keepInParent then
 		-- move all items in this group its subgroups to the parent
@@ -126,7 +126,7 @@ end
 local function MoveGroup(groupPath, newPath)
 	if not TSM.db.profile.groups[groupPath] then return end
 	if TSM.db.profile.groups[newPath] then return end
-	
+
 	-- change the path of all subgroups
 	local changes = {}
 	for path, groupData in pairs(TSM.db.profile.groups) do
@@ -138,7 +138,7 @@ local function MoveGroup(groupPath, newPath)
 		TSM.db.profile.groups[newPath] = TSM.db.profile.groups[oldPath]
 		TSM.db.profile.groups[oldPath] = nil
 	end
-	
+
 	-- change the path for all items in this group (and subgroups)
 	changes = {}
 	for itemString, path in pairs(TSM.db.profile.items) do
@@ -155,7 +155,7 @@ end
 local function AddItem(itemString, path)
 	if not (strfind(path, TSM.GROUP_SEP) or not TSM.db.profile.items[itemString]) then return end
 	if not TSM.db.profile.groups[path] then return end
-	
+
 	TSM.db.profile.items[itemString] = path
 end
 
@@ -186,7 +186,7 @@ end
 local function SetOperation(path, module, operation, index)
 	if not TSM.db.profile.groups[path] then return end
 	if not TSM.db.profile.groups[path][module] then return end
-	
+
 	TSM.db.profile.groups[path][module][index] = operation
 	local subGroups = GetSubGroups(path)
 	if subGroups then
@@ -198,7 +198,7 @@ end
 
 local function AddOperation(path, module)
 	if not TSM.db.profile.groups[path] then return end
-	
+
 	tinsert(TSM.db.profile.groups[path][module], "")
 	local subGroups = GetSubGroups(path)
 	if subGroups then
@@ -219,7 +219,7 @@ end
 
 function SetOperationOverride(path, module, override)
 	if not TSM.db.profile.groups[path] then return end
-	
+
 	-- clear all operations for this path/module
 	TSM.db.profile.groups[path][module] = {override=(override or nil)}
 	-- set this group's (and all applicable subgroups') operation to the parent's
@@ -253,7 +253,7 @@ function TSM:GetGroupPathList(module)
 		end
 		tinsert(list, groupPath)
 	end
-	
+
 	for groupPath in pairs(TSM.db.profile.groups) do
 		if not disabled[groupPath] then
 			local pathParts = {TSM.GROUP_SEP:split(groupPath)}
@@ -263,14 +263,14 @@ function TSM:GetGroupPathList(module)
 			end
 		end
 	end
-	
+
 	sort(list, function(a,b) return strlower(gsub(a, TSM.GROUP_SEP, "\001")) < strlower(gsub(b, TSM.GROUP_SEP, "\001")) end)
 	return list, disabled
 end
 
 function TSM:GetGroupOperations(path, module)
 	if not TSM.db.profile.groups[path] then return end
-	
+
 	if module and TSM.db.profile.groups[path][module] then
 		local operations = CopyTable(TSM.db.profile.groups[path][module])
 		for i=#operations, 1, -1 do
@@ -304,7 +304,7 @@ function TSMAPI:CreatePresetGroups(itemList, moduleName, operationInfo)
 			end
 		end
 	end
-	
+
 	private:UpdateTree()
 end
 
@@ -339,13 +339,13 @@ local function ShowExportFrame(text)
 	f:SetTitle("TradeSkillMaster - "..L["Export Group Items"])
 	f:SetLayout("Fill")
 	f:SetHeight(300)
-	
+
 	local eb = AceGUI:Create("TSMMultiLineEditBox")
 	eb:SetLabel(L["Group Item Data"])
 	eb:SetMaxLetters(0)
 	eb:SetText(text)
 	f:AddChild(eb)
-	
+
 	f.frame:SetFrameStrata("FULLSCREEN_DIALOG")
 	f.frame:SetFrameLevel(100)
 end
@@ -367,12 +367,12 @@ function TSMAPI:DrawOperationManagement(TSMObj, container, operationName)
 	for playerName in pairs(TSM.db.realm.characters) do
 		playerList[playerName.." - "..realmKey] = playerName
 	end
-	
+
 	local realmList = {}
 	for realm in pairs(TSM.db.sv.realm) do
 		realmList[realm] = realm
 	end
-	
+
 	local groupList = {}
 	for path, modules in pairs(TSM.db.profile.groups) do
 		if modules[moduleName] then
@@ -384,7 +384,7 @@ function TSMAPI:DrawOperationManagement(TSMObj, container, operationName)
 		end
 	end
 	sort(groupList, function(a,b) return strlower(gsub(a, TSM.GROUP_SEP, "\001")) < strlower(gsub(b, TSM.GROUP_SEP, "\001")) end)
-	
+
 	local groupWidgets = {
 		{
 			type = "Label",
@@ -422,7 +422,7 @@ function TSMAPI:DrawOperationManagement(TSMObj, container, operationName)
 				text = TSMAPI:FormatGroupPath(groupPath, true),
 			})
 	end
-	
+
 	local page = {
 		{
 			type = "ScrollFrame",
@@ -645,7 +645,7 @@ function TSMAPI:DrawOperationManagement(TSMObj, container, operationName)
 			},
 		},
 	}
-	
+
 	TSMAPI:BuildPage(container, page)
 end
 
@@ -707,7 +707,7 @@ function TSMAPI:ShowOperationRelationshipTab(obj, container, operation, settingI
 		end
 	end
 	sort(operationListOrder)
-	
+
 	local target = ""
 	local children = {
 		{
@@ -794,8 +794,8 @@ function TSMAPI:ShowOperationRelationshipTab(obj, container, operation, settingI
 		}
 		tinsert(children, inlineGroup)
 	end
-	
-	
+
+
 	local page = {
 		{
 			type = "ScrollFrame",
@@ -803,7 +803,7 @@ function TSMAPI:ShowOperationRelationshipTab(obj, container, operation, settingI
 			children = children,
 		},
 	}
-	
+
 	TSMAPI:BuildPage(container, page)
 end
 
@@ -843,7 +843,7 @@ function TSM:LoadOperationOptions(parent)
 			end
 		end)
 	parent:AddChild(tabGroup)
-	
+
 	tabGroup:SelectTab(TSM.loadModuleOptionsTab and TSM.loadModuleOptionsTab.module or "Help")
 end
 
@@ -867,7 +867,7 @@ function private:DrawOperationHelp(container)
 			},
 		},
 	}
-	
+
 	TSMAPI:BuildPage(container, page)
 end
 
@@ -882,7 +882,7 @@ function TSM:LoadGroupOptions(parent)
 	treeGroup:SetCallback("OnGroupSelected", function(...) private:SelectTree(...) end)
 	treeGroup:SetStatusTable(TSM.db.profile.groupTreeStatus)
 	parent:AddChild(treeGroup)
-	
+
 	private:UpdateTree()
 	treeGroup:SelectByPath(1)
 end
@@ -908,7 +908,7 @@ local function UpdateTreeHelper(currentPath, groupPathList, index, treeGroupChil
 end
 function private:UpdateTree()
 	if not treeGroup then return end
-	
+
 	local groupChildren = {}
 	local groupPathList = TSM:GetGroupPathList()
 	UpdateTreeHelper(nil, groupPathList, 1, groupChildren, 1)
@@ -929,7 +929,7 @@ end
 local scrollFrameStatus = {}
 function private:SelectTree(treeGroup, _, selection)
 	treeGroup:ReleaseChildren()
-	
+
 	selection = {("\001"):split(selection)}
 	if #selection == 1 then
 		private:DrawNewGroup(treeGroup)
@@ -1040,7 +1040,7 @@ function private:DrawNewGroup(container)
 			},
 		},
 	}
-	
+
 	TSMAPI:BuildPage(container, page)
 end
 
@@ -1055,7 +1055,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 		for name in pairs(TSM.operations[moduleName] or {}) do
 			ddList[name] = name
 		end
-		
+
 		TSM.db.profile.groups[groupPath][moduleName] = TSM.db.profile.groups[groupPath][moduleName] or {}
 		local operations = TSM.db.profile.groups[groupPath][moduleName]
 		for i=#operations, 1, -1 do
@@ -1074,7 +1074,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 			title = moduleName,
 			children = {},
 		}
-		
+
 		local addOperationWidget
 		if #operations < info.maxOperations then
 			addOperationWidget = {
@@ -1105,7 +1105,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 		else
 			tinsert(moduleInline.children, {type="Label", relativeWidth=1})
 		end
-		
+
 		for i=1, #operations do
 			tinsert(moduleInline.children, {
 					type = "Dropdown",
@@ -1149,7 +1149,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 			end
 		end
 		tinsert(moduleInline.children, addOperationWidget)
-		
+
 		local opStrs = {}
 		for _, name in ipairs(operations) do
 			if name ~= "" then
@@ -1163,12 +1163,12 @@ function private:DrawGroupOperationsPage(container, groupPath)
 				text = #opStrs > 0 and table.concat(opStrs, "\n") or format(L["Select a %s operation using the dropdown above."], moduleName),
 				relativeWidth = 1,
 			})
-		
+
 		tinsert(moduleInlines, moduleInline)
 	end
-	
+
 	sort(moduleInlines, function(a, b) return a.title < b.title end)
-	
+
 	local children = {}
 	for i, inline in ipairs(moduleInlines) do
 		tinsert(children, inline)
@@ -1176,7 +1176,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 			tinsert(children, {type="Spacer"})
 		end
 	end
-	
+
 	local page = {
 		{
 			type = "ScrollFrame",
@@ -1184,7 +1184,7 @@ function private:DrawGroupOperationsPage(container, groupPath)
 			children = children,
 		},
 	}
-	
+
 	TSMAPI:BuildPage(container, page)
 end
 
@@ -1194,7 +1194,7 @@ function private:DrawGroupItemsPage(container, groupPath)
 		alreadyLoaded[groupPath] = true
 		TSMAPI:CreateTimeDelay("itemsTabLoad", 0.1, function() container:ReloadTab() end)
 	end
-	
+
 	local parentPath, groupName = SplitGroupPath(groupPath)
 	local function GetItemList(side)
 		local list = {}
@@ -1240,7 +1240,7 @@ function private:DrawGroupItemsPage(container, groupPath)
 		end
 		return list
 	end
-	
+
 	local leftTitle, rightTitle
 	if parentPath then
 		if TSM.db.profile.directSubgroupAdd then
@@ -1253,7 +1253,7 @@ function private:DrawGroupItemsPage(container, groupPath)
 		leftTitle = L["Ungrouped Items:"]
 		rightTitle = L["Group Items:"]
 	end
-	
+
 	local page = {
 		{	-- scroll frame to contain everything
 			type = "SimpleGroup",
@@ -1298,7 +1298,7 @@ function TSM:ImportGroup(importStr, groupPath)
 	importStr = importStr:trim()
 	if importStr == "" then return end
 	local parentPath = strfind(groupPath, TSM.GROUP_SEP) and SplitGroupPath(groupPath)
-	
+
 	if strfind(importStr, "^|c") then
 		local itemString = TSMAPI:GetItemString(importStr)
 		if not itemString then return end
@@ -1312,8 +1312,9 @@ function TSM:ImportGroup(importStr, groupPath)
 		end
 		return 0
 	end
-	
+
 	local items = {}
+	local bulkquerybuffer = {}
 	local currentSubPath = ""
 	for _, str in ipairs(TSMAPI:SafeStrSplit(importStr, ",")) do
 		str = str:trim()
@@ -1331,16 +1332,19 @@ function TSM:ImportGroup(importStr, groupPath)
 			if not tonumber(itemID) or not tonumber(randomEnchant) then return end
 			itemString = "item:"..tonumber(itemID)..":0:0:0:0:0:"..tonumber(randomEnchant)
 		end
-		
+
 		if subPath then
 			currentSubPath = subPath
 		elseif itemString then
 			items[itemString] = currentSubPath
+			local item = Item:CreateFromID(tonumber(noSpaceStr))
+			if not item:IsCached() then bulkquerybuffer[#bulkquerybuffer+1] = item.itemID end
 		else
 			return
 		end
 	end
-	
+	TSMAPI:BulkQuery(bulkquerybuffer)
+
 	local num = 0
 	for itemString, subPath in pairs(items) do
 		if not (parentPath and TSM.db.profile.moveImportedItems and TSM.db.profile.importParentOnly and TSM.db.profile.items[itemString] ~= parentPath) then
@@ -1614,7 +1618,7 @@ function private:DrawGroupManagementPage(container, groupPath)
 									if TSM.db.profile.groups[newPath] then
 										return TSM:Printf(L["Error moving group. Group '%s' already exists."], TSMAPI:FormatGroupPath(newPath, true))
 									end
-									
+
 									TSM:Printf(L["Moved %s to %s."], TSMAPI:FormatGroupPath(groupPath, true), TSMAPI:FormatGroupPath(value, true))
 									MoveGroup(groupPath, newPath)
 									TSMAPI:FireEvent("TSM:GROUPS:MOVEGROUP", {old=groupPath, new=newPath})
@@ -1634,7 +1638,7 @@ function private:DrawGroupManagementPage(container, groupPath)
 								if TSM.db.profile.groups[newPath] then
 									return TSM:Printf(L["Error moving group. Group '%s' already exists."], TSMAPI:FormatGroupPath(newPath, true))
 								end
-								
+
 								TSM:Printf(L["Moved %s to %s."], TSMAPI:FormatGroupPath(groupPath, true), TSMAPI:FormatGroupPath(newPath, true))
 								MoveGroup(groupPath, newPath)
 								TSMAPI:FireEvent("TSM:GROUPS:MOVEGROUP", {old=groupPath, new=newPath})

--- a/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
+++ b/TradeSkillMaster_Crafting/Modules/CraftingGUI.lua
@@ -50,7 +50,6 @@ function GUI:OnEnable()
 	GUI:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "EventHandler")
 	GUI:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", "EventHandler")
 	GUI:RegisterEvent("UNIT_SPELLCAST_FAILED", "EventHandler")
-	GUI:RegisterEvent("UNIT_SPELLCAST_FAILED_QUIET", "EventHandler")
 	GUI:RegisterEvent("GUILDBANKFRAME_OPENED", "GatheringEventHandler")
 	GUI:RegisterEvent("GUILDBANKFRAME_CLOSED", "GatheringEventHandler")
 	GUI:RegisterEvent("GUILDBANKBAGSLOTS_CHANGED", "GatheringEventHandler")
@@ -240,7 +239,7 @@ function GUI:EventHandler(event, ...)
 			-- no longer casting a spell so discard spellID
 			TSM.currentspell = nil
 			-- TSMAPI:CreateTimeDelay("craftingQueueUpdateThrottle", 0.2, GUI.UpdateQueue)
-		elseif event == "UNIT_SPELLCAST_INTERRUPTED" or event == "UNIT_SPELLCAST_FAILED" or event == "UNIT_SPELLCAST_FAILED_QUIET" then
+		elseif event == "UNIT_SPELLCAST_INTERRUPTED" or event == "UNIT_SPELLCAST_FAILED" then
 			local unit = ...
 			if unit ~= "player" then return end
 


### PR DESCRIPTION
Event never seems to fire during normal crafting, however several talents pulse the event hidden from the player.  Causes crafts to not be properly removed from queue if player has a related talent.

Make sure that if a user uses the item string import filter for building their list that the related item ids are in their cache.  Otherwise the items won't appear in their lists until a relog/reload.