### PR TITLE
Couple of fixes and a new feature for bank/GB

### DIFF
--- a/TradeSkillMaster/Core/Groups.lua
+++ b/TradeSkillMaster/Core/Groups.lua
@@ -1315,6 +1315,7 @@ function TSM:ImportGroup(importStr, groupPath)
 
 	local items = {}
 	local currentSubPath = ""
+	local itemID, randomEnchant = nil, nil
 	for _, str in ipairs(TSMAPI:SafeStrSplit(importStr, ",")) do
 		str = str:trim()
 		local noSpaceStr = gsub(str, " ", "") -- forums like to add spaces
@@ -1327,7 +1328,7 @@ function TSM:ImportGroup(importStr, groupPath)
 		elseif strfind(noSpaceStr, "p") then
 			itemString = gsub(noSpaceStr, "p", "battlepet")
 		elseif strfind(noSpaceStr, ":") then
-			local itemID, randomEnchant = (":"):split(noSpaceStr)
+			itemID, randomEnchant = (":"):split(noSpaceStr)
 			if not tonumber(itemID) or not tonumber(randomEnchant) then return end
 			itemString = "item:"..tonumber(itemID)..":0:0:0:0:0:"..tonumber(randomEnchant)
 		end
@@ -1336,8 +1337,13 @@ function TSM:ImportGroup(importStr, groupPath)
 			currentSubPath = subPath
 		elseif itemString then
 			items[itemString] = currentSubPath
-			local item = Item:CreateFromID(tonumber(noSpaceStr))
-			item:Query()
+			itemID = itemID or noSpaceStr
+			if Item then
+				local item = Item:CreateFromID(tonumber(itemID))
+				item:Query()
+			else
+				TSMAPI:GetSafeItemInfo(tonumber(itemID))
+			end
 		else
 			return
 		end

--- a/TradeSkillMaster/Core/Options.lua
+++ b/TradeSkillMaster/Core/Options.lua
@@ -943,8 +943,12 @@ function private:LoadProfilesPage(container)
 			-- check if item is cached
 			local _,_,itemID = itemString:find("item:(%d+)")
 			if itemID then
-				local item = Item:CreateFromID(itemID)
-				item:Query()
+				if Item then
+					local item = Item:CreateFromID(itemID)
+					item:Query()
+				else
+					TSMAPI:GetSafeItemInfo(tonumber(itemID))
+				end
 			end
 		end
 

--- a/TradeSkillMaster/GUI/BuildPage.lua
+++ b/TradeSkillMaster/GUI/BuildPage.lua
@@ -303,6 +303,7 @@ local Add = {
 				else
 					TSM:Print(L["Invalid custom price."].." "..err)
 					self:SetFocus()
+					return
 				end
 			else
 				args.callback(self, event, value)

--- a/TradeSkillMaster/TradeSkillMaster.lua
+++ b/TradeSkillMaster/TradeSkillMaster.lua
@@ -239,8 +239,12 @@ function TSM:OnInitialize()
 		-- check if item is cached
 		local _,_,itemID = itemString:find("item:(%d+)")
 		if itemID then
-			local item = Item:CreateFromID(itemID)
-			item:Query()
+			if Item then
+				local item = Item:CreateFromID(itemID)
+				item:Query()
+			else
+				TSMAPI:GetSafeItemInfo(tonumber(itemID))
+			end
 		end
 		if strfind(itemString, " ") then
 			local newItemString = gsub(itemString, " ", "")

--- a/TradeSkillMaster_Auctioning/modules/Util.lua
+++ b/TradeSkillMaster_Auctioning/modules/Util.lua
@@ -221,6 +221,29 @@ function Util:groupTree(grpInfo, src, all, ah)
 			end
 			if newgrp[itemString] < 0 then
 				newgrp[itemString] = nil
+			else
+				-- Get the group's auction operation
+				local operations = TSMAPI:GetItemOperation(itemString, "Auctioning")
+				if operations and operations[1] then
+					local operation = TSM.operations[operations[1]]
+					if operation then
+						-- Get the prices
+						local prices = TSM.Util:GetItemPrices(operation, itemString)
+						local marketValue = TSMAPI:GetItemValue(itemString, "DBMarket")
+						local currentMinPrice = TSMAPI:GetItemValue(itemString, "DBMinBuyout")
+	
+						-- Compare the prices
+						if prices.minPrice and prices.maxPrice and prices.normalPrice then
+							if marketValue and currentMinPrice then
+								if prices.minPrice > currentMinPrice then
+									-- Handle the case where the prices do not meet the criteria
+									-- For example, you can remove the item from the group
+									newgrp[itemString] = nil
+								end
+							end
+						end
+					end
+				end
 			end
 		end
 	end

--- a/TradeSkillMaster_Crafting/Modules/Cost.lua
+++ b/TradeSkillMaster_Crafting/Modules/Cost.lua
@@ -110,11 +110,12 @@ function Cost:GetLowestCraftPrices(itemString, intermediate)
 	if not spellIDs then return end
 	local lowestCost, cheapestSpellID
 	local soh = "item:76061:0:0:0:0:0:0" -- Spirit of Harmony
+	local fb = "item:800405:0:0:0:0:0:0" -- Fel Blood
 	for _, spellID in ipairs(spellIDs) do
 		if TSM.db.realm.crafts[spellID] then
-			if intermediate and (TSM.db.realm.crafts[spellID].mats[soh] or TSM.db.realm.crafts[spellID].hasCD) then
+			if intermediate and (TSM.db.realm.crafts[spellID].mats[soh] or TSM.db.realm.crafts[spellID].mats[fb] or TSM.db.realm.crafts[spellID].hasCD) then
 				break
-			end --exclude spells using SOH or have cooldown from intermediate crafts
+			end --exclude spells using SOH and FB or have cooldown from intermediate crafts
 			local cost = Cost:GetCraftCost(spellID)
 			if cost and (not lowestCost or cost < lowestCost) then
 				-- exclude spells with cooldown if option to ignore is enabled or more than one way to craft and not soulbound e.g. BoE

--- a/TradeSkillMaster_Mailing/Modules/Inbox.lua
+++ b/TradeSkillMaster_Mailing/Modules/Inbox.lua
@@ -711,7 +711,7 @@ function Inbox:UI_ERROR_MESSAGE(event, msg)
 			return
 		end
 
-		TSMAPI:CreateTimeDelay("mailWaitDelay", 0.3, private.AutoLoot)
+		TSMAPI:CreateTimeDelay("mailWaitDelay", math.max(5/GetFramerate(), 0.3), private.AutoLoot)
 	end
 end
 


### PR DESCRIPTION
Epoch lua error fix
bank/GB withdraw based on AH Shortfall also include minPrice for items. (Used to be only post Cap).
Slowed down mail looting when low fps to avoid double loot of same mail.
Avoid using Fel Blood in craft calculations.


**Item Handling and Fallbacks:**
* Added fallback to `TSMAPI:GetSafeItemInfo` in `Groups.lua`, `Options.lua`, and `TradeSkillMaster.lua` when the `Item` object is unavailable, ensuring robust item info retrieval across different contexts. [[1]](diffhunk://#diff-5863aa5a0a11aa766e1b283417b95fb7ec6faf24bdf971f7f5eeb04187bc1f2fL1339-R1346) [[2]](diffhunk://#diff-9d9a1404415b1fb9d068df6c6f13a00ab5e02a16036210b4d7ac9b5d8f2d4733R946-R951) [[3]](diffhunk://#diff-b4b459c772b0c7e7f792514a560335dab503d34866e2a840ca152299a35bdff3R242-R247)

**Auction Group Logic:**
[Allowing withdrawing items from bank/GB using "AH shortfall" to withdraw based on post cap and now ALSO minPrice of those items has to be above current DBMinBuyout.](https://github.com/Ascension-Addons/TradeSkillMaster/commit/9656b053d5272f64b4a55e693b003147f9685bd8)


**Crafting Cost Calculation:**
* Updated crafting cost exclusion logic in `Cost.lua` to also exclude crafts using "Fel Blood" (`item:800405`) in addition to "Spirit of Harmony", making intermediate crafting cost calculations more precise.

**UI Responsiveness:**
* Improved mail looting delay in `Inbox.lua` to be dynamically based on framerate, reducing errors and enhancing user experience during auto-loot operations.

**Code Consistency:**
* Refactored variable handling in `Groups.lua` for item import, ensuring consistent assignment and usage of `itemID` and `randomEnchant` throughout the function. [[1]](diffhunk://#diff-5863aa5a0a11aa766e1b283417b95fb7ec6faf24bdf971f7f5eeb04187bc1f2fR1318) [[2]](diffhunk://#diff-5863aa5a0a11aa766e1b283417b95fb7ec6faf24bdf971f7f5eeb04187bc1f2fL1330-R1331)