### PR TITLE
fix: Multiple bug fixes for accounting and item transfer

### DIFF
--- a/TradeSkillMaster/Core/Mover.lua
+++ b/TradeSkillMaster/Core/Mover.lua
@@ -267,14 +267,12 @@ end
 local function findExistingStack(itemLink, dest, quantity, gbank)
 	for i, bag in ipairs(getContainerTable(dest)) do
 		if gbank then
-			if bag == GetCurrentGuildBankTab() then
-				for slot = 1, TSM.getContainerNumSlotsDest(bag) do
-					if TSM.getContainerItemIDDest(bag, slot) == TSMAPI:GetBaseItemString(itemLink, true) then
-						local maxStack = select(8, TSMAPI:GetSafeItemInfo(itemLink))
-						local _, currentQuantity = TSM.getContainerItemIDDest(bag, slot)
-						if currentQuantity and (currentQuantity + quantity) <= maxStack then
-							return bag, slot
-						end
+			for slot = 1, TSM.getContainerNumSlotsDest(bag) do
+				if TSM.getContainerItemIDDest(bag, slot) == TSMAPI:GetBaseItemString(itemLink, true) then
+					local maxStack = select(8, TSMAPI:GetSafeItemInfo(itemLink))
+					local _, currentQuantity = TSM.getContainerItemIDDest(bag, slot)
+					if currentQuantity and (currentQuantity + quantity) <= maxStack then
+						return bag, slot
 					end
 				end
 			end
@@ -349,7 +347,6 @@ function TSM.generateMoves(includeSoulbound)
 			bankMoves[itemString] = quantity - currentQty
 		end
 	end
-
 	if next(bagMoves) ~= nil then -- generate moves from bags to bank
 		setSrcBagFunctions("bags")
 		setDestBagFunctions(bankType)
@@ -363,13 +360,15 @@ function TSM.generateMoves(includeSoulbound)
 							local have = TSM.getContainerItemQty(bag, slot)
 							local need = bagMoves[itemString]
 							if have and need then
-								-- check if the source item stack can fit into a destination bag
 								local destBag
 								if bankType == "guildbank" then
 									destBag = findExistingStack(itemLink, bankType, min(have, need), true)
 									if not destBag then
-										if GetEmptySlotCount(GetCurrentGuildBankTab()) ~= false then
-											destBag = GetCurrentGuildBankTab()
+										for _, tab in ipairs(getContainerTable(bankType)) do
+											if GetEmptySlotCount(tab) ~= false then
+												destBag = tab
+												break
+											end
 										end
 									end
 								else
@@ -519,13 +518,42 @@ function TSM.moveItem()
 			local need = fullMoves[i].quantity
 			if have and need then
 				if bankType == "guildbank" then
-					if findExistingStack(itemLink, bankType, need, true) then
-						TSM.autoStoreItem(fullMoves[i].bag, fullMoves[i].slot)
-					elseif GetEmptySlotCount(GetCurrentGuildBankTab()) then
+					local destTab, destSlot = findExistingStack(itemLink, bankType, need, true)
+					if destTab then
+						if GetCurrentGuildBankTab() ~= destTab then
+							SetCurrentGuildBankTab(destTab)
+						end
 						TSM.autoStoreItem(fullMoves[i].bag, fullMoves[i].slot)
 					else
-						TSMAPI:CancelFrame("moveItem")
-						TSMAPI:CreateTimeDelay("generateMoves", 0.4, TSM.generateMoves)
+						destTab = nil
+						for _, tab in ipairs(getContainerTable(bankType)) do
+							if GetEmptySlotCount(tab) ~= false then
+								destTab = tab
+								break
+							end
+						end
+						if destTab then
+							if GetCurrentGuildBankTab() ~= destTab then
+								SetCurrentGuildBankTab(destTab)
+							end
+							destSlot = nil
+							for s = 1, TSM.getContainerNumSlotsDest(destTab) do
+								if not TSM.getContainerItemLinkDest(destTab, s) then
+									destSlot = s
+									break
+								end
+							end
+							if destSlot then
+								TSM.pickupContainerItemSrc(fullMoves[i].bag, fullMoves[i].slot)
+								TSM.pickupContainerItemDest(destTab, destSlot)
+							else
+								TSMAPI:CancelFrame("moveItem")
+								TSMAPI:CreateTimeDelay("generateMoves", 0.4, TSM.generateMoves)
+							end
+						else
+							TSMAPI:CancelFrame("moveItem")
+							TSMAPI:CreateTimeDelay("generateMoves", 0.4, TSM.generateMoves)
+						end
 					end
 				else
 					if findExistingStack(itemLink, bankType, need) then

--- a/TradeSkillMaster/Core/Mover.lua
+++ b/TradeSkillMaster/Core/Mover.lua
@@ -18,13 +18,40 @@ local ascensionBankType
 local fullMoves, splitMoves, bagState = {}, {}, {}
 local callbackMsg = {}
 
+local BANK_TYPE_PERSONAL = "personal"
+local BANK_TYPE_REALM = "realm"
+
 local function GetAscensionBankType()
-	if GuildBankFrame and GuildBankFrame.IsPersonalBank then
-		return "personal"
-	elseif GuildBankFrame and GuildBankFrame.IsRealmBank then
-		return "realm"
+	local detectedPersonal = nil
+	local detectedRealm = nil
+
+	-- Primary: detect from JSON cache payload (same approach as Bagnon)
+	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
+		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
+		if json then
+			local jsonObject = C_Serialize:FromJSON(json)
+			if jsonObject then
+				detectedPersonal = jsonObject.IsPersonalBank
+				detectedRealm = jsonObject.IsRealmBank
+			end
+		end
 	end
-	return nil
+
+	-- Fallback to first tab name only if JSON detection yielded nothing
+	if not detectedPersonal and not detectedRealm then
+		local numTabs = GetNumGuildBankTabs()
+		local firstTabName = numTabs > 0 and GetGuildBankTabInfo(1) or nil
+		detectedPersonal = (firstTabName == "Personal Bank")
+		detectedRealm = (firstTabName == "Realm Bank")
+	end
+
+	if detectedPersonal then
+		return BANK_TYPE_PERSONAL
+	elseif detectedRealm then
+		return BANK_TYPE_REALM
+	else
+		return nil
+	end
 end
 
 -- this is a set of wrapper functions so that I can switch

--- a/TradeSkillMaster_Accounting/Modules/data.lua
+++ b/TradeSkillMaster_Accounting/Modules/data.lua
@@ -15,6 +15,7 @@ local private = {}
 TSMAPI:RegisterForTracing(private, "TSM_Accounting.Data_private")
 
 local SECONDS_PER_DAY = 24 * 60 * 60
+local EXPIRY_TIME = 365
 local TIME_BUCKET = 300 -- group sales/buys within 5 minutes together
 local REPAIR_COST, REPAIR_MONEY, COULD_REPAIR, CAN_REPAIR = 0, 0, false, ""
 local expired = AUCTION_EXPIRED_MAIL_SUBJECT:gsub("%%s", "")
@@ -123,12 +124,12 @@ function Data:Load()
 	private:LoadItemRecords(TSM.db.realm.csvBuys, "buys")
 	private:LoadItemRecords(TSM.db.realm.csvCancelled, "auctions", "Cancel")
 	private:LoadItemRecords(TSM.db.realm.csvExpired, "auctions", "Expire")
-	
+
 	-- Decode money records
 	TSM.money = {}
 	private:LoadMoneyRecords(TSM.db.realm.csvIncome, "income")
 	private:LoadMoneyRecords(TSM.db.realm.csvExpense, "expense")
-	
+
 	-- Decode the gold log
 	for player, data in pairs(TSM.db.realm.goldLog) do
 		if type(data) == "string" then
@@ -375,7 +376,7 @@ function Data:ScanCollectedMail(oFunc, attempt, index, subIndex)
 
 	if invoiceType == "seller" and buyer and buyer ~= "" then -- AH Sales
 		local daysLeft = select(7, GetInboxHeaderInfo(index))
-		local saleTime = (time() + (daysLeft - 30) * SECONDS_PER_DAY)
+		local saleTime = (time() + (daysLeft - EXPIRY_TIME) * SECONDS_PER_DAY)
 		local link = select(2, TSMAPI:GetSafeItemInfo(itemName))
 		local itemString = TSM.db.global.itemStrings[itemName] or TSMAPI:GetItemString(link)
 		local quantity = select(11, GetInboxInvoiceInfo(index)) or 1 -- WotLK doesn't provide quantity sold by default, Ascension does
@@ -545,19 +546,19 @@ function private:IsItemFiltered(itemString, filters)
 	name = name or TSM.items[itemString].name
 	rarity = rarity or 0
 	if not name then return true end
-	
+
 	if filters.name and not strfind(strlower(name), strlower(filters.name)) then
 		return true
 	end
-	
+
 	if filters.rarity and rarity ~= filters.rarity then
 		return true
 	end
-	
+
 	if not TSM.db.realm.displayGreys and rarity == 0 then
 		return true
 	end
-	
+
 	if filters.group then
 		local groupPath = TSMAPI:GetGroupPath(itemString)
 		if not groupPath or not strfind(groupPath, "^"..TSMAPI:StrEscape(filters.group)) then
@@ -644,7 +645,7 @@ end
 
 function private:GetItemSummaryData(filters, includeProfit)
 	local itemData = {}
-	
+
 	for itemString, data in pairs(TSM.items) do
 		if not private:IsItemFiltered(itemString, filters) then
 			local sellTotal, sellNum = 0, 0
@@ -869,18 +870,18 @@ function Data.GetSummaryData(filters)
 		monthTime = 0,
 		weekTime = 0,
 	}
-	
-	
+
+
 	local function ProcessSummaryItemData(itemData, resultTbl, itemString)
 		local itemTotal, itemNum = 0, 0
 		for _, record in ipairs(itemData) do
 			if not private:IsRecordFiltered(record, filters) then
 				local timeDiff = time() - record.time
-				
+
 				-- update local variables
 				itemNum = itemNum + record.quantity
 				itemTotal = itemTotal + record.copper * record.quantity
-				
+
 				-- update total data
 				resultTbl.total = resultTbl.total + record.copper * record.quantity
 				goldData.totalTime = max(goldData.totalTime, timeDiff)
@@ -896,7 +897,7 @@ function Data.GetSummaryData(filters)
 				end
 			end
 		end
-		
+
 		-- check if this is a top item by gold and/or quantity
 		if itemTotal > (resultTbl.topGold.copper or 0) then
 			resultTbl.topGold = {itemString=itemString, copper=itemTotal, itemID=TSMAPI:GetItemID(itemString)}
@@ -911,18 +912,18 @@ function Data.GetSummaryData(filters)
 			ProcessSummaryItemData(data.buys, goldData.buys, itemString)
 		end
 	end
-	
-	
+
+
 	local function ProcessSummaryMoneyData(moneyData, resultTbl)
 		local moneyKeyNum, moneyKeyGold = {}, {}
 		for _, record in ipairs(moneyData) do
 			if not private:IsRecordFiltered(record, filters) then
 				local timeDiff = time() - record.time
-				
+
 				-- update local variables
 				moneyKeyNum[record.key] = (moneyKeyNum[record.key] or 0) + 1
 				moneyKeyGold[record.key] = (moneyKeyGold[record.key] or 0) + record.copper
-				
+
 				-- update total data
 				resultTbl.total = resultTbl.total + record.copper
 				goldData.totalTime = max(goldData.totalTime, timeDiff)
@@ -952,16 +953,16 @@ function Data.GetSummaryData(filters)
 	ProcessSummaryMoneyData(TSM.money.income, goldData.income)
 	ProcessSummaryMoneyData(TSM.money.expense, goldData.expense)
 
-	
+
 	goldData.sales.topGold.link = goldData.sales.topGold.itemString and (select(2, TSMAPI:GetSafeItemInfo(goldData.sales.topGold.itemString)) or TSM.items[goldData.sales.topGold.itemString].name) or L["none"]
 	goldData.sales.topQuantity.link = goldData.sales.topQuantity.itemString and (select(2, TSMAPI:GetSafeItemInfo(goldData.sales.topQuantity.itemString)) or TSM.items[goldData.sales.topQuantity.itemString].name) or L["none"]
 	goldData.buys.topGold.link = goldData.buys.topGold.itemString and (select(2, TSMAPI:GetSafeItemInfo(goldData.buys.topGold.itemString)) or TSM.items[goldData.buys.topGold.itemString].name) or L["none"]
 	goldData.buys.topQuantity.link = goldData.buys.topQuantity.itemString and (select(2, TSMAPI:GetSafeItemInfo(goldData.buys.topQuantity.itemString)) or TSM.items[goldData.buys.topQuantity.itemString].name) or L["none"]
-	
+
 	goldData.profit.total = ((goldData.sales.total + goldData.income.total) - (goldData.buys.total + goldData.expense.total))
 	goldData.profit.month = ((goldData.sales.month + goldData.income.month) - (goldData.buys.month + goldData.expense.month))
 	goldData.profit.week = ((goldData.sales.week + goldData.income.week) - (goldData.buys.week + goldData.expense.week))
-	
+
 	if goldData.totalTime > (SECONDS_PER_DAY * 30) then
 		goldData.monthTime = SECONDS_PER_DAY * 30
 	end
@@ -979,7 +980,7 @@ function Data.GetItemDetailData(itemString)
 	if not TSM.items[itemString] then return end
 
 	local data = {activity={}, buys={players={}, price={}, num={}, avg={}}, sales={players={}, price={}, num={}, avg={}}, stData={}}
-	
+
 	local function ProcessItemActivity(itemData, resultTbl, activityType)
 		local totalPrice, totalNum = 0, 0
 		local monthPrice, monthNum = 0, 0
@@ -1001,26 +1002,26 @@ function Data.GetItemDetailData(itemString)
 				weekNum = weekNum + record.quantity
 			end
 		end
-		
+
 		resultTbl.price.total = totalPrice
 		resultTbl.price.month = monthPrice
 		resultTbl.price.week = weekPrice
-		
+
 		resultTbl.num.total = totalNum
 		resultTbl.num.month = monthNum
 		resultTbl.num.week = weekNum
-		
+
 		resultTbl.avg.total = totalNum > 0 and TSM:Round(totalPrice / totalNum) or 0
 		resultTbl.avg.month = monthNum > 0 and TSM:Round(monthPrice / monthNum) or 0
 		resultTbl.avg.week = weekNum > 0 and TSM:Round(weekPrice / weekNum) or 0
-		
+
 		if totalNum > 0 then
 			resultTbl.hasData = true
 		end
 	end
 	ProcessItemActivity(TSM.items[itemString].buys, data.buys, "Purchase")
 	ProcessItemActivity(TSM.items[itemString].sales, data.sales, "Sale")
-	
+
 	for _, stRecord in ipairs(data.activity) do
 		local activityType = stRecord.activityType
 		local record = stRecord.record
@@ -1067,7 +1068,7 @@ end
 
 function Data:PopulateDataCaches()
 	Data.playerListCache = {}
-	
+
 	for itemString, data in pairs(TSM.items) do
 		for _, record in ipairs(data.buys) do
 			Data.playerListCache[record.player] = record.player
@@ -1079,7 +1080,7 @@ function Data:PopulateDataCaches()
 			Data.playerListCache[record.player] = record.player
 		end
 	end
-	
+
 	for _, record in pairs(TSM.money.income) do
 		Data.playerListCache[record.player] = record.player
 	end
@@ -1091,7 +1092,7 @@ end
 function Data:RemoveOldData(daysOld)
 	local cutOffTime = time() - daysOld * SECONDS_PER_DAY
 	local numRecords, numItems = 0, 0
-	
+
 	for itemString, data in pairs(TSM.items) do
 		local numLeft = 0
 		for _, key in ipairs({"sales", "buys", "auctions"}) do

--- a/TradeSkillMaster_Accounting/Modules/data.lua
+++ b/TradeSkillMaster_Accounting/Modules/data.lua
@@ -97,7 +97,7 @@ function private:LoadItemRecords(csvData, recordType, key)
 			TSM.cache[itemString] = {}
 		end
 	end
-	for itemString in ipairs(TSM.items) do
+	for itemString in pairs(TSM.items) do
 		sort(TSM.items[itemString][recordType], function(a, b) return (a.time or 0) < (b.time or 0) end)
 	end
 end

--- a/TradeSkillMaster_Accounting/Modules/data.lua
+++ b/TradeSkillMaster_Accounting/Modules/data.lua
@@ -377,6 +377,7 @@ function Data:ScanCollectedMail(oFunc, attempt, index, subIndex)
 
 	if invoiceType == "seller" and buyer and buyer ~= "" then -- AH Sales
 		local daysLeft = select(7, GetInboxHeaderInfo(index))
+		-- Offset is always 365 days for all items when selling
 		local saleTime = (time() + (daysLeft - EXPIRY_TIME) * SECONDS_PER_DAY)
 		local link = select(2, TSMAPI:GetSafeItemInfo(itemName))
 		local itemString = TSM.db.global.itemStrings[itemName] or TSMAPI:GetItemString(link)
@@ -407,7 +408,17 @@ function Data:ScanCollectedMail(oFunc, attempt, index, subIndex)
 
 			local copper = floor(bid / quantity + 0.5)
 			local daysLeft = select(7, GetInboxHeaderInfo(index))
-			local buyTime = (time() + (daysLeft - 30) * SECONDS_PER_DAY)
+
+			-- Set offset based on days left when buying. For Vanity items, days
+			-- left is 365. For other items, days left is 30.
+			if daysLeft > 30 then
+				-- Vanity items
+				offset = EXPIRY_TIME
+			else
+				-- Other items
+				offset = 30
+			end
+			local buyTime = (time() + (daysLeft - offset) * SECONDS_PER_DAY)
 			Data:InsertItemBuyRecord(itemString, "Auction", quantity, copper, buyer, buyTime)
 		end
 	elseif codAmount > 0 then -- COD Buys (only if all attachments are same item)

--- a/TradeSkillMaster_Accounting/Modules/data.lua
+++ b/TradeSkillMaster_Accounting/Modules/data.lua
@@ -17,6 +17,7 @@ TSMAPI:RegisterForTracing(private, "TSM_Accounting.Data_private")
 local SECONDS_PER_DAY = 24 * 60 * 60
 local EXPIRY_TIME = 365
 local TIME_BUCKET = 300 -- group sales/buys within 5 minutes together
+local COD_EXPIRY_TIME = 6/24 -- 6 hours
 local REPAIR_COST, REPAIR_MONEY, COULD_REPAIR, CAN_REPAIR = 0, 0, false, ""
 local expired = AUCTION_EXPIRED_MAIL_SUBJECT:gsub("%%s", "")
 local cancelled = AUCTION_REMOVED_MAIL_SUBJECT:gsub("%%s", "")
@@ -418,23 +419,19 @@ function Data:ScanCollectedMail(oFunc, attempt, index, subIndex)
 						stacks = stacks + 1
 					else
 						ignore = true
+						TSM:Printf("COD Buys - different item found, ignoring from accounting")
 					end
 				end
 			end
 
 			if total ~= 0 and not ignore and private:CanLootMailIndex(index) then
---				local copper = floor(codAmount / total + 0.5)
 				local daysLeft = select(7, GetInboxHeaderInfo(index))
-				local buyTime = (time() + (daysLeft - 3) * SECONDS_PER_DAY)
---				local maxStack = select(8, TSMAPI:GetSafeItemInfo(link))
-				Data:InsertItemBuyRecord(itemString, "COD", total, codAmount, sender, buyTime)
---[[				for i = 1, stacks do
-					local stackSize = (total >= maxStack) and maxStack or total
-					Data:InsertItemBuyRecord(itemString, "COD", stackSize, copper, sender, buyTime)
-					total = total - stackSize
-					if total <= 0 then break end
-				end
-]]			end
+				local buyTime = (time() + (daysLeft - COD_EXPIRY_TIME) * SECONDS_PER_DAY)
+
+				-- Normalize per stack price
+				local stackPrice = floor(codAmount / total + 0.5)
+				Data:InsertItemBuyRecord(itemString, "COD", total, stackPrice, sender, buyTime)
+			end
 		end
 	elseif money > 0 and invoiceType ~= "seller" and not strfind(subject, outbid) then
 		local str

--- a/TradeSkillMaster_Accounting/Modules/data.lua
+++ b/TradeSkillMaster_Accounting/Modules/data.lua
@@ -385,6 +385,17 @@ function Data:ScanCollectedMail(oFunc, attempt, index, subIndex)
 			local copper = floor((bid - ahcut) / quantity + 0.5)
 			Data:InsertItemSaleRecord(itemString, "Auction", quantity, copper, buyer, saleTime)
 		end
+	elseif (string.find(subject, "COD Payment:") ~= nil) then -- COD Sales
+		local itemName = string.match(subject, "COD Payment: (.+) %((%d+)%)")
+		local quantity = string.match(subject, "COD Payment: .+ %((%d+)%)")
+		local daysLeft = select(7, GetInboxHeaderInfo(index))
+		local saleTime = (time() + (daysLeft - EXPIRY_TIME) * SECONDS_PER_DAY)
+		local link = select(2, TSMAPI:GetSafeItemInfo(itemName))
+		local itemString = TSM.db.global.itemStrings[itemName] or TSMAPI:GetItemString(link)
+		if itemString and private:CanLootMailIndex(index) then
+			local copper = floor(money / quantity + 0.5)
+			Data:InsertItemSaleRecord(itemString, "COD", quantity, copper, sender, saleTime)
+		end
 	elseif invoiceType == "buyer" and buyer and buyer ~= "" then -- AH Buys
 		local link = GetInboxItemLink(index, 1)
 		local itemString = TSMAPI:GetItemString(link)

--- a/TradeSkillMaster_Auctioning/modules/Util.lua
+++ b/TradeSkillMaster_Auctioning/modules/Util.lua
@@ -41,9 +41,9 @@ end
 
 function Util:GetItemPrices(operation, itemString, isResetScan)
 	local prices = {}
-	
+
 	prices.cost = GetItemPrice("crafting", itemString)
-	
+
 	prices.undercut = GetItemPrice(operation.undercut, itemString)
 	prices.minPrice = GetItemPrice(operation.minPrice, itemString)
 	prices.maxPrice = GetItemPrice(operation.maxPrice, itemString)
@@ -202,6 +202,11 @@ function Util:groupTree(grpInfo, src, all, ah)
 									end
 								end
 							end
+						elseif not all then
+							local bagQty = bagItems[itemString] or 0
+							if bagQty > maxPost then
+								newgrp[itemString] = (newgrp[itemString] or 0) + (maxPost - bagQty)
+							end
 						end
 					end
 				end
@@ -231,7 +236,7 @@ function Util:groupTree(grpInfo, src, all, ah)
 						local prices = TSM.Util:GetItemPrices(operation, itemString)
 						local marketValue = TSMAPI:GetItemValue(itemString, "DBMarket")
 						local currentMinPrice = TSMAPI:GetItemValue(itemString, "DBMinBuyout")
-	
+
 						-- Compare the prices
 						if prices.minPrice and prices.maxPrice and prices.normalPrice then
 							if marketValue and currentMinPrice then

--- a/TradeSkillMaster_ItemTracker/Modules/data.lua
+++ b/TradeSkillMaster_ItemTracker/Modules/data.lua
@@ -206,12 +206,16 @@ local function ScanGuildBankSlots()
 	for tab = 1, numTabs do
 		local name, icon, isViewable, canDeposit, numWithdrawals = GetGuildBankTabInfo(tab)
 		local canAccess = false
+
 		if currentOpenBankType == BANK_TYPE_GUILD then
 			canAccess = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player"))
+		elseif currentOpenBankType == BANK_TYPE_PERSONAL or currentOpenBankType == BANK_TYPE_REALM then
+			-- For personal/realm banks, just detect string to support any tab names
+			canAccess = name and type(name) == "string"
 		else
-			-- Ascension WoW: For Personal/Realm banks, always scan (numWithdrawals check may not apply)
-			canAccess = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player")) or (name == "Personal Bank") or (name == "Realm Bank")
+			error("Unknown bank type: " .. currentOpenBankType)
 		end
+
 		if canAccess then
 			for slot = 1, MAX_GUILDBANK_SLOTS_PER_TAB or 98 do
 				local link = GetGuildBankItemLink(tab, slot)

--- a/TradeSkillMaster_ItemTracker/Modules/data.lua
+++ b/TradeSkillMaster_ItemTracker/Modules/data.lua
@@ -19,6 +19,7 @@ local isScanning = false
 function Data:Initialize()
 	Data:RegisterEvent("GUILDBANKFRAME_OPENED", "EventHandler")
 	Data:RegisterEvent("GUILDBANKBAGSLOTS_CHANGED", "EventHandler")
+	Data:RegisterEvent("GUILDBANKFRAME_CLOSED", "EventHandler")
 	Data:RegisterEvent("AUCTION_OWNED_LIST_UPDATE", "EventHandler")
 	TSMAPI:RegisterForBagChange(function(...) Data:GetBagData(...) end)
 	TSMAPI:RegisterForBankChange(function(...) Data:GetBankData(...) end)
@@ -82,43 +83,86 @@ local BANK_TYPE_PERSONAL = "personal"
 local BANK_TYPE_REALM = "realm"
 local BANK_TYPE_GUILD = "guild"
 
-local function GetCurrentBankType()
-	if GuildBankFrame and GuildBankFrame.IsPersonalBank then
-		return BANK_TYPE_PERSONAL
-	elseif GuildBankFrame and GuildBankFrame.IsRealmBank then
-		return BANK_TYPE_REALM
+-- Bank type state: set on OPENED, cleared on CLOSED (inspired by Bagnon's db.lua)
+local currentOpenBankType = nil
+
+local function DetectBankType()
+	local detectedPersonal = nil
+	local detectedRealm = nil
+
+	-- Primary: detect from JSON cache payload (same approach as Bagnon)
+	if HasJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0) then
+		local json = GetJsonCacheData("BANK_PERMISSIONS_PAYLOAD", 0)
+		if json then
+			local jsonObject = C_Serialize:FromJSON(json)
+			if jsonObject then
+				detectedPersonal = jsonObject.IsPersonalBank
+				detectedRealm = jsonObject.IsRealmBank
+			end
+		end
+	end
+
+	-- Fallback to first tab name only if JSON detection yielded nothing
+	if not detectedPersonal and not detectedRealm then
+		local numTabs = GetNumGuildBankTabs()
+		local firstTabName = numTabs > 0 and GetGuildBankTabInfo(1) or nil
+		detectedPersonal = (firstTabName == "Personal Bank")
+		detectedRealm = (firstTabName == "Realm Bank")
+	end
+
+	if detectedPersonal then
+		currentOpenBankType = BANK_TYPE_PERSONAL
+	elseif detectedRealm then
+		currentOpenBankType = BANK_TYPE_REALM
 	else
-		return BANK_TYPE_GUILD
+		currentOpenBankType = BANK_TYPE_GUILD
 	end
 end
 
--- Store the current bank type when opened (persists until next open)
-local currentOpenBankType = nil
+local function ClearBankType()
+	currentOpenBankType = nil
+end
 
 function Data:EventHandler(event, fire)
 	if isScanning then return end
+
+	-- Handle open/close immediately without throttling (like Bagnon)
+	if event == "GUILDBANKFRAME_OPENED" then
+		DetectBankType()
+
+		-- Query all accessible tabs to preload data (inspired by Bagnon)
+		local initialTab = GetCurrentGuildBankTab()
+		for tab = 1, GetNumGuildBankTabs() do
+			local name, icon, isViewable, canDeposit, numWithdrawals = GetGuildBankTabInfo(tab)
+			local canQuery = false
+			if currentOpenBankType == BANK_TYPE_GUILD then
+				canQuery = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player"))
+			else
+				canQuery = type(name) == "string"
+			end
+			if canQuery then
+				QueryGuildBankTab(tab)
+			end
+		end
+		QueryGuildBankTab(initialTab)
+		return
+	end
+
+	if event == "GUILDBANKFRAME_CLOSED" then
+		ClearBankType()
+		return
+	end
+
+	-- Throttle remaining events (GUILDBANKBAGSLOTS_CHANGED, AUCTION_OWNED_LIST_UPDATE)
 	if fire ~= "FIRE" then
 		Data:ThrottleEvent(event)
 	else
-		if event == "GUILDBANKFRAME_OPENED" then
-			-- Detect and store the bank type
-			currentOpenBankType = GetCurrentBankType()
-
-			-- Query all tabs of the gbank to ensure all tabs will be scanned.
-			local initialTab = GetCurrentGuildBankTab()
-			for tab = 1, GetNumGuildBankTabs() do
-				if select(5, GetGuildBankTabInfo(tab)) > 0 or IsGuildLeader(UnitName("player")) then
-					QueryGuildBankTab(tab)
-				end
-			end
-			QueryGuildBankTab(initialTab)
-		elseif event == "GUILDBANKBAGSLOTS_CHANGED" then
-			-- Route to the appropriate handler based on bank type
+		if event == "GUILDBANKBAGSLOTS_CHANGED" then
 			if currentOpenBankType == BANK_TYPE_PERSONAL then
 				Data:GetPersonalBankData()
 			elseif currentOpenBankType == BANK_TYPE_REALM then
 				Data:GetRealmBankData()
-			else
+			elseif currentOpenBankType == BANK_TYPE_GUILD then
 				Data:GetGuildBankData()
 			end
 		elseif event == "AUCTION_OWNED_LIST_UPDATE" then
@@ -161,13 +205,19 @@ local function ScanGuildBankSlots()
 	local numTabs = GetNumGuildBankTabs()
 	for tab = 1, numTabs do
 		local name, icon, isViewable, canDeposit, numWithdrawals = GetGuildBankTabInfo(tab)
-		-- Ascension WoW: For Personal/Realm banks, always scan (numWithdrawals check may not apply)
-		local canAccess = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player")) or (name == "Personal Bank") or (name == "Realm Bank")
+		local canAccess = false
+		if currentOpenBankType == BANK_TYPE_GUILD then
+			canAccess = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player"))
+		else
+			-- Ascension WoW: For Personal/Realm banks, always scan (numWithdrawals check may not apply)
+			canAccess = (numWithdrawals and numWithdrawals > 0) or IsGuildLeader(UnitName("player")) or (name == "Personal Bank") or (name == "Realm Bank")
+		end
 		if canAccess then
 			for slot = 1, MAX_GUILDBANK_SLOTS_PER_TAB or 98 do
-				local itemString = TSMAPI:GetItemString(GetGuildBankItemLink(tab, slot))
-				local baseItemString = TSMAPI:GetBaseItemString(GetGuildBankItemLink(tab, slot))
+				local link = GetGuildBankItemLink(tab, slot)
+				local itemString = TSMAPI:GetItemString(link)
 				if itemString then
+					local baseItemString = TSMAPI:GetBaseItemString(link)
 					local quantity = select(2, GetGuildBankItemInfo(tab, slot))
 					items[itemString] = (items[itemString] or 0) + quantity
 					if itemString ~= baseItemString then
@@ -193,15 +243,12 @@ function Data:GetGuildBankData()
 		TSM.guilds[TSM.CURRENT_GUILD].items[itemString] = quantity
 	end
 
-	if GuildBankFrame and GuildBankFrame:IsVisible() then
-		TSM.guilds[TSM.CURRENT_GUILD].lastUpdate = time()
-	end
+	TSM.guilds[TSM.CURRENT_GUILD].lastUpdate = time()
 	TSM.Sync:BroadcastUpdateRequest()
 end
 
 -- Ascension WoW: scan the personal bank (per character)
 function Data:GetPersonalBankData()
-	-- Initialize personal bank for current player if needed
 	if not TSM.personalBanks[TSM.CURRENT_PLAYER] then
 		TSM.personalBanks[TSM.CURRENT_PLAYER] = { items = {}, lastUpdate = 0 }
 	end
@@ -218,7 +265,6 @@ end
 
 -- Ascension WoW: scan the realm bank (shared across realm)
 function Data:GetRealmBankData()
-	-- Initialize realm bank if needed
 	if not TSM.realmBank.items then
 		TSM.realmBank.items = {}
 	end
@@ -229,9 +275,7 @@ function Data:GetRealmBankData()
 		TSM.realmBank.items[itemString] = quantity
 	end
 
-	if GuildBankFrame and GuildBankFrame:IsVisible() then
-		TSM.realmBank.lastUpdate = time()
-	end
+	TSM.realmBank.lastUpdate = time()
 	TSM.Sync:BroadcastUpdateRequest()
 end
 
@@ -303,7 +347,7 @@ do
 		end
 		tinsert(TSM.characters[player].mailInbox, index, data)
 	end
-	
+
 	local function RemoveInboxMail(player, index)
 		local playerMail = TSM.characters[player].mail
 		for _, itemData in ipairs(TSM.characters[player].mailInbox[index].items) do
@@ -324,7 +368,7 @@ do
 		end
 		tremove(TSM.characters[player].mailInbox, index)
 	end
-	
+
 	local function RemoveInboxMailItem(player, index, itemIndex)
 		local playerMail = TSM.characters[player].mail
 		local itemData = TSM.characters[player].mailInbox[index].items[itemIndex]
@@ -358,7 +402,7 @@ do
 		if not items then error() end
 		InsertInboxMail(player, 1, {items=items, index=nil})
 	end
-	
+
 	local function RemoveMailItem(index, itemIndex)
 		local link = GetInboxItemLink(index, itemIndex)
 		if not link then return end
@@ -378,8 +422,8 @@ do
 			end
 		end
 	end
-	
-	
+
+
 	local tmpBuyouts = {}
 	local function OnAuctionBid(listType, index, bidPlaced)
 		local link = GetAuctionItemLink(listType, index)
@@ -401,7 +445,7 @@ do
 			end
 		end
 	end
-	
+
 	local function OnAuctionCanceled(index)
 		local link = GetAuctionItemLink("owner", index)
 		local count = select(3, GetAuctionItemInfo("owner", index))
@@ -429,7 +473,7 @@ do
 		AddIncomingMail(altName, items)
 		tinsert(playersToUpdate, altName)
 	end
-	
+
 	local function OnTakeInboxItem(index, itemIndex)
 		for i = (itemIndex or 1), (itemIndex or ATTACHMENTS_MAX_RECEIVE) do
 			local link = GetInboxItemLink(index, i)
@@ -438,7 +482,7 @@ do
 			end
 		end
 	end
-	
+
 	local function OnReturnMail(index)
 		local sender = select(3, GetInboxHeaderInfo(index))
 		local items = {}
@@ -462,7 +506,7 @@ do
 		if numItems == totalItems then
 			wipe(player.mailInbox)
 		end
-		
+
 		local index = 1
 		for i=1, numItems do
 			local items = {}
@@ -485,7 +529,7 @@ do
 							temp[data.link] = temp[data.link] - data.count
 							if temp[data.link] == 0 then temp[data.link] = nil end
 						end
-						
+
 						if not next(temp) then
 							matchIndex = k
 							break


### PR DESCRIPTION
Fixes an issue where the personal and realm bank information wasn't read correctly due to the null GuildBankFrame variable.
JSON approach seems more stable but there's also a fallback to first tab name.

Throttle events to avoid race conditions and clear bank type on close

As a side effect, we have significantly sped up the movement of items in TSM since the bank types are now checked correctly.

Moreover:
- I added an unrelated fix for mailing and accounting where sold items on AH would have null / empty value in accounting tab because of a wrong date offset
- Let moves to the bank iterate over multiple tabs to avoid getting stuck when there are more empty slots available
- 'Move Post Cap To Bags' wouldn't move an item to bank (happens when we have too many of an item in bags) when the item doesn't already exist in the bank.
- Use correct unit price for COD buys (normalize total price by # items)
- Use correct buy time for COD (6 hours expiry time instead of 3 days)
- Correctly saves COD sells in accounting
- Fixes buy time when buying vanity items (expiry is 365 days for vanity, 30 days for other)